### PR TITLE
%MESSAGE% substitution in IRC/MessageListener

### DIFF
--- a/src/main/java/com/cnaude/purpleirc/IRC/MessageListener.java
+++ b/src/main/java/com/cnaude/purpleirc/IRC/MessageListener.java
@@ -97,8 +97,8 @@ public class MessageListener extends ListenerAdapter {
         } else {
             if (ircBot.enabledMessages.get(myChannel).contains("irc-chat")) {
                 plugin.getServer().broadcast(plugin.colorConverter.ircColorsToGame(plugin.ircChat)
-                        .replace("%NAME%", user.getNick()
-                        .replace("%MESSAGE%", message))
+                        .replace("%NAME%", user.getNick())
+                        .replace("%MESSAGE%", message)
                         .replace("%CHANNEL%", channel.getName()), "irc.message.chat");
             }
         }


### PR DESCRIPTION
Messages from IRC to bukkit aren't substituted to the %MESSAGE% macro in MessageListener  because the replacement is applied to user.getNick()
