### PR TITLE
have command listener listen at a higher priority

### DIFF
--- a/main/java/com/cnaude/purpleirc/GameListeners/GamePlayerCommandPreprocessingListener.java
+++ b/main/java/com/cnaude/purpleirc/GameListeners/GamePlayerCommandPreprocessingListener.java
@@ -45,7 +45,7 @@ public class GamePlayerCommandPreprocessingListener implements Listener {
      *
      * @param event
      */
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.HIGH)
     public void onPlayerCommandPreprocessEvent(PlayerCommandPreprocessEvent event) {
         if (event.isCancelled()) {
             return;


### PR DESCRIPTION
Not sure why this is listening at lowest...? Also makes it impossible for plugins that depend on PurpleIRC (and thus load after PurpleIRC) to cancel.
